### PR TITLE
修复冰雪键道不能同步的问题

### DIFF
--- a/lua/snow/table_like.lua
+++ b/lua/snow/table_like.lua
@@ -50,6 +50,12 @@ function t12.func(input, segment, env)
   end
 end
 
+---@param env ProxyTranslatorEnv
+function t12.fini(env)
+  env.translator = nil
+  collectgarbage()
+end
+
 local jianpin = {}
 
 ---@param env ProxyTranslatorEnv
@@ -92,6 +98,12 @@ function jianpin.func(input, segment, env)
       end
     end
   end
+end
+
+---@param env ProxyTranslatorEnv
+function jianpin.fini(env)
+  env.translator = nil
+  collectgarbage()
 end
 
 return {


### PR DESCRIPTION
table_like.lua 的 env.translator 占用了 UserDb，增加 fini 部分销毁 env.translator。